### PR TITLE
update deprecated call

### DIFF
--- a/lib/espinita/auditor_request.rb
+++ b/lib/espinita/auditor_request.rb
@@ -2,7 +2,7 @@ module Espinita::AuditorRequest
   extend ActiveSupport::Concern
 
   included do 
-    before_filter :store_audited_user
+    before_action :store_audited_user
   end
 
   def store_audited_user


### PR DESCRIPTION
In Rails 5, an application using `espinita` shows the warning below:

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in Rails 5.1. 
Use before_action instead.
```