### PR TITLE
Fix deprecation warning in Rails 5

### DIFF
--- a/lib/espinita/auditor_request.rb
+++ b/lib/espinita/auditor_request.rb
@@ -1,8 +1,12 @@
 module Espinita::AuditorRequest 
   extend ActiveSupport::Concern
 
-  included do 
-    before_filter :store_audited_user
+  included do
+    if respond_to?(:before_action)
+      before_action :store_audited_user
+    else
+      before_filter :store_audited_user
+    end
   end
 
   def store_audited_user


### PR DESCRIPTION
This will fix the deprecation warning introduced by Rails 5. 